### PR TITLE
[BUGFIX] TYPO3 10.4 remove order by alias

### DIFF
--- a/Classes/Utility/SlugsUtility.php
+++ b/Classes/Utility/SlugsUtility.php
@@ -292,10 +292,10 @@ class SlugsUtility
           $queryBuilder->andWhere( $queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($lang, \PDO::PARAM_INT)));
           }
         */
-        // Ensure that fields with alias are managed first
-        return $queryBuilder->orderBy('alias', 'desc')
+
+        return $queryBuilder
             // Ensure that live workspace records are handled first
-            ->addOrderBy('t3ver_wsid', 'asc')
+            ->orderBy('t3ver_wsid', 'asc')
             // Ensure that all pages are run through "per parent page" field, and in the correct sorting values
             ->addOrderBy('pid', 'asc')
             ->addOrderBy('sorting', 'asc')


### PR DESCRIPTION
In TYPO3 10.4 there is no alias-field, so there is a backend-error. Removing this order by solves the error. But I do not know the implications on functionality...