### PR TITLE
[FEATURE] Select infinite depth as default

### DIFF
--- a/Classes/Controller/SlugController.php
+++ b/Classes/Controller/SlugController.php
@@ -58,7 +58,12 @@ class SlugController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
         $pageRenderer->addInlineLanguageLabelFile('EXT:ig_slug/Resources/Private/Language/locallang.xlf');
 
         $this->lang = isset($this->search['lang'])  && $this->search['lang']!='' ? intval($this->search['lang']) : null;
-        $this->depth = isset($this->search['depth']) ? intval($this->search['depth']) : 0;
+        
+        $this->extConf = GeneralUtility::makeInstance(
+            \TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class
+        )->get('ig_slug');
+        $this->defaultInfiniteDepth = ($this->extConf['defaultInfiniteDepth'] == 1) ? 999 : 0;
+        $this->depth = isset($this->search['depth']) ? intval($this->search['depth']) : $this->defaultInfiniteDepth;
 
 
         $this->slugsUtility->setTable($this->slugTable['table']);

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,2 +1,5 @@
   # cat=basic/enable; type=boolean; label=Show in info module:Disable own menu item and add it to info module
 disableOwnMenuItem = 0
+
+  # cat=basic/enable; type=boolean; label=Default infinite depth:Select infinite depth by default
+defaultInfiniteDepth = 0


### PR DESCRIPTION
Adds an option in the extension configuration to select infinite depth as default in the backend module.