### PR TITLE
Adding PHP 8.2 compatibility (dynamic member properties)

### DIFF
--- a/Classes/Controller/SlugController.php
+++ b/Classes/Controller/SlugController.php
@@ -28,6 +28,14 @@ class SlugController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
     protected int $depth = 0; // get from .....
     protected ?ModuleData $moduleData = null;
     protected ModuleTemplate $moduleTemplate;
+    protected int $pageUid = 0;
+    protected ?SlugsUtility $slugsUtility = null;
+    protected $siteLanguages = null;
+    protected $pageinfo = null;
+    protected ?int $lang = 0;
+    protected $slugTables;
+    protected $slugTable;
+    protected $activeTable;
 
     
     public function __construct(

--- a/Classes/Utility/SlugUtility.php
+++ b/Classes/Utility/SlugUtility.php
@@ -22,6 +22,7 @@ class SlugUtility
     protected $hasToBeUniqueInPid;
     protected $hasToBeUniqueInTable;
     protected $fieldNamesToShow;
+    protected $flags;
   
     /**
      * Instantiate the form protection before a simulated user is initialized.
@@ -67,7 +68,7 @@ class SlugUtility
         if ($pid === -1) {
             $pid = $this->getLiveVersionPid($record['t3ver_oid']);
         }
-        $slugLocked= isset($this->slugLockedFieldName) && $record[$this->slugLockedFieldName]==1;
+        $slugLocked= isset($this->slugLockedFieldName) && isset($record[$this->slugLockedFieldName]) && $record[$this->slugLockedFieldName]==1;
         if ($slugLocked) {
             $slug=$record[$this->slugFieldName];
         } else {

--- a/Classes/Utility/SlugsUtility.php
+++ b/Classes/Utility/SlugsUtility.php
@@ -26,6 +26,8 @@ class SlugsUtility
     protected int $countUpdates = 0;
     protected int $maxDepth = 100;
     protected array $siteLanguagesIds = [];
+    protected $siteLanguages;
+    protected $slugUtility;
 
 
     /**


### PR DESCRIPTION
Hi!

First off, great extension and thanks for sharing - and keeping it updated for TYPO3v12!

I found that there are some minor object member hints missing to run successfully with PHP 8.2, which my patch adds. Hope you like it and can integrate it into the official version.