### PR TITLE
Module: Admins without explicit permission can't edit slugs

### DIFF
--- a/Classes/Utility/SlugsUtility.php
+++ b/Classes/Utility/SlugsUtility.php
@@ -116,14 +116,18 @@ class SlugsUtility
         int $lang = null
     ): array {
         if (
-            !$this->getBackendUser()
-->check('tables_modify', $this->table)
-            ||
-            (
-                $GLOBALS['TCA'][$this->table]['columns'][$this->slugFieldName]['exclude'] ?? false
-                && !$this->getBackendUser()
-->check('non_exclude_fields', $this->table . ':' . $this->slugFieldName)
-            )
+			(
+				!$this->getBackendUser()
+	->check('tables_modify', $this->table)
+				||
+				(
+					$GLOBALS['TCA'][$this->table]['columns'][$this->slugFieldName]['exclude'] ?? false
+					&& !$this->getBackendUser()
+	->check('non_exclude_fields', $this->table . ':' . $this->slugFieldName)
+				)
+			)
+			&&
+			!$this->getBackendUser()->isAdmin()
         ) {
             return [];
         }


### PR DESCRIPTION
Check extended because admins without explicit permission for the table were not allowed to see it in the module. Permissions should not be set for admins because they should be allowed to do everything